### PR TITLE
Add recipe book support

### DIFF
--- a/src/main/java/hibi/scooters/mixin/InputSlotFillerMixin.java
+++ b/src/main/java/hibi/scooters/mixin/InputSlotFillerMixin.java
@@ -1,0 +1,49 @@
+package hibi.scooters.mixin;
+
+import hibi.scooters.Common;
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.InputSlotFiller;
+import net.minecraft.screen.slot.Slot;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(InputSlotFiller.class)
+public class InputSlotFillerMixin {
+    @Shadow protected PlayerInventory inventory;
+
+    private ItemStack scooters$storedStack;
+
+    @Inject(method = "fillInputSlot", at = @At("HEAD"))
+    private void storeStack(Slot slot, ItemStack stack, CallbackInfo ci) {
+        scooters$storedStack = stack;
+    }
+
+    @Inject(method = "fillInputSlot", at = @At(value = "JUMP", ordinal = 0))
+    private void releaseStack(Slot slot, ItemStack stack, CallbackInfo ci) {
+        scooters$storedStack = null;
+    }
+
+    // I don't know why MCDev complains, but it works, so
+    @SuppressWarnings("InvalidInjectorMethodSignature")
+    @ModifyVariable(method = "fillInputSlot", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/entity/player/PlayerInventory;indexOf(Lnet/minecraft/item/ItemStack;)I", shift = At.Shift.AFTER))
+    private int fillInScooters(int slotId) {
+        if (slotId != -1) return slotId;
+
+        var stack = scooters$storedStack;
+
+        if (!stack.isOf(Common.KICK_SCOOTER_ITEM) && !stack.isOf(Common.TIRE_ITEM)) return slotId;
+
+        for(int i = 0; i < this.inventory.main.size(); ++i) {
+            ItemStack otherStack = this.inventory.main.get(i);
+            if (!otherStack.isEmpty() && ItemStack.areItemsEqual(stack, otherStack) && !otherStack.isDamaged() && !otherStack.hasEnchantments() && !otherStack.hasCustomName()) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/src/main/java/hibi/scooters/recipes/ElectricScooterRecipe.java
+++ b/src/main/java/hibi/scooters/recipes/ElectricScooterRecipe.java
@@ -8,6 +8,7 @@ import net.minecraft.recipe.Ingredient;
 import net.minecraft.recipe.RecipeSerializer;
 import net.minecraft.recipe.SpecialCraftingRecipe;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.collection.DefaultedList;
 import net.minecraft.world.World;
 
 public class ElectricScooterRecipe
@@ -53,6 +54,21 @@ extends SpecialCraftingRecipe {
 	}
 
 	@Override
+	public DefaultedList<Ingredient> getIngredients() {
+		return RECIPE;
+	}
+
+	@Override
+	public boolean isIgnoredInRecipeBook() {
+		return false;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return false;
+	}
+
+	@Override
 	public RecipeSerializer<?> getSerializer() {
 		return Common.ELECTRIC_SCOOTER_CRAFTING_SERIALIZER;
 	}
@@ -66,4 +82,6 @@ extends SpecialCraftingRecipe {
 		Ingredient.ofItems(Items.REDSTONE_TORCH),  Ingredient.ofItems(Common.KICK_SCOOTER_ITEM), Ingredient.ofItems(Items.REDSTONE),
 		Ingredient.ofItems(Items.NETHERITE_SCRAP), Ingredient.ofItems(Items.NETHERITE_SCRAP),    Ingredient.ofItems(Items.REDSTONE)
 	};
+
+	private static final DefaultedList<Ingredient> RECIPE = DefaultedList.copyOf(Ingredient.EMPTY, INPUT);
 }

--- a/src/main/java/hibi/scooters/recipes/KickScooterRecipe.java
+++ b/src/main/java/hibi/scooters/recipes/KickScooterRecipe.java
@@ -88,6 +88,16 @@ extends SpecialCraftingRecipe {
 		return Common.KICK_SCOOTER_ITEM.getDefaultStack().copy();
 	}
 
+	@Override
+	public boolean isIgnoredInRecipeBook() {
+		return false;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return false;
+	}
+
 	private static final Ingredient[] INPUT = {
 		Ingredient.EMPTY,                     Ingredient.EMPTY,                                        Ingredient.fromTag(ItemTags.WOOL),
 		Ingredient.ofItems(Items.IRON_INGOT), Ingredient.EMPTY,                                        Ingredient.ofItems(Items.IRON_BARS),

--- a/src/main/resources/scooters.mixin.json
+++ b/src/main/resources/scooters.mixin.json
@@ -7,7 +7,8 @@
     "GrindstoneScreenHandlerMixin",
     "ClientPlayerEntityMixin",
     "PlayerEntityModelMixin",
-    "BipedEntityModelMixin"
+    "BipedEntityModelMixin",
+    "InputSlotFillerMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This PR also makes tires and kick scooters get filled in recipes regardless of whether they have extra NBT.