### PR TITLE
Add recipe advancements

### DIFF
--- a/src/main/resources/data/scooters/advancements/recipes/charging_station.json
+++ b/src/main/resources/data/scooters/advancements/recipes/charging_station.json
@@ -1,0 +1,46 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_quartz": {
+      "conditions": {
+        "items": [
+          {
+            "tag": "c:quartz"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_electric_scooter": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "scooters:electric_scooter"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "scooters:charging_station"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_quartz",
+      "has_electric_scooter",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "scooters:charging_station"
+    ]
+  },
+  "sends_telemetry_event": false
+}

--- a/src/main/resources/data/scooters/advancements/recipes/copper_ingot_from_nuggets.json
+++ b/src/main/resources/data/scooters/advancements/recipes/copper_ingot_from_nuggets.json
@@ -1,0 +1,35 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_copper_nugget": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "scooters:copper_nugget"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "scooters:copper_ingot_from_nuggets"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_copper_nugget",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "scooters:copper_ingot_from_nuggets"
+    ]
+  },
+  "sends_telemetry_event": false
+}

--- a/src/main/resources/data/scooters/advancements/recipes/copper_nugget_from_ingot.json
+++ b/src/main/resources/data/scooters/advancements/recipes/copper_nugget_from_ingot.json
@@ -1,0 +1,33 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_copper_ingot": {
+      "conditions": {
+        "items": [
+          {
+			"tag": "c:copper_ingots"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "scooters:copper_nugget_from_ingot"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_copper_ingot",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "scooters:copper_nugget_from_ingot"
+    ]
+  },
+  "sends_telemetry_event": false
+}

--- a/src/main/resources/data/scooters/advancements/recipes/electric_scooter.json
+++ b/src/main/resources/data/scooters/advancements/recipes/electric_scooter.json
@@ -1,0 +1,74 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_netherite_scrap": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:netherite_scrap"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_kick_scooter": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "scooters:kick_scooter"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_charging_station": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "scooters:charging_station"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_potato_battery": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "scooters:potato_battery"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "scooters:electric_scooter"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_netherite_scrap",
+      "has_charging_station",
+      "has_potato_battery",
+      "has_kick_scooter",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "scooters:electric_scooter"
+    ]
+  },
+  "sends_telemetry_event": false
+}

--- a/src/main/resources/data/scooters/advancements/recipes/kick_scooter.json
+++ b/src/main/resources/data/scooters/advancements/recipes/kick_scooter.json
@@ -1,0 +1,74 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_iron_ingot": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:iron_ingot"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+	"has_iron_pressure_plate": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:heavy_weighted_pressure_plate"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+	"has_iron_bars": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:iron_bars"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+	"has_tire": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "scooters:tire"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "scooters:kick_scooter"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_iron_ingot",
+      "has_iron_bars",
+      "has_iron_pressure_plate",
+      "has_tire",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "scooters:kick_scooter"
+    ]
+  },
+  "sends_telemetry_event": false
+}

--- a/src/main/resources/data/scooters/advancements/recipes/patching_tire.json
+++ b/src/main/resources/data/scooters/advancements/recipes/patching_tire.json
@@ -1,0 +1,35 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+	"has_tire": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "scooters:tire"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "scooters:patching_tire"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_tire",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "scooters:patching_tire"
+    ]
+  },
+  "sends_telemetry_event": false
+}

--- a/src/main/resources/data/scooters/advancements/recipes/potato_battery.json
+++ b/src/main/resources/data/scooters/advancements/recipes/potato_battery.json
@@ -1,0 +1,105 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_potato": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:potato"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_iron_ingot": {
+      "conditions": {
+        "items": [
+          {
+            "tag": "c:iron_ingots"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_copper_ingot": {
+      "conditions": {
+        "items": [
+          {
+            "tag": "c:copper_ingots"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_iron_nugget": {
+      "conditions": {
+        "items": [
+          {
+            "tag": "c:iron_nuggets"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_copper_nugget": {
+      "conditions": {
+        "items": [
+          {
+            "tag": "c:copper_nuggets"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+	"has_electric_scooter": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "scooters:electric_scooter"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_charging_station": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "scooters:charging_station"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "scooters:potato_battery"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_potato",
+      "has_iron_ingot",
+      "has_iron_nugget",
+      "has_copper_ingot",
+      "has_copper_nugget",
+      "has_electric_scooter",
+      "has_charging_station",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "scooters:potato_battery"
+    ]
+  },
+  "sends_telemetry_event": false
+}

--- a/src/main/resources/data/scooters/advancements/recipes/potato_battery_with_zinc.json
+++ b/src/main/resources/data/scooters/advancements/recipes/potato_battery_with_zinc.json
@@ -1,0 +1,105 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_potato": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:potato"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_zing_ingot": {
+      "conditions": {
+        "items": [
+          {
+            "tag": "c:zinc_ingots"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_zinc_nugget": {
+      "conditions": {
+        "items": [
+          {
+            "tag": "c:zinc_nuggets"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_copper_ingot": {
+      "conditions": {
+        "items": [
+          {
+            "tag": "c:copper_ingots"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_copper_nugget": {
+      "conditions": {
+        "items": [
+          {
+            "tag": "c:copper_nuggets"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+	"has_electric_scooter": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "scooters:electric_scooter"
+            ]
+          }
+        ]
+      },
+    "has_charging_station": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "scooters:charging_station"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "scooters:potato_battery_with_zinc"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_potato",
+      "has_zinc_ingot",
+      "has_zinc_nugget",
+      "has_copper_ingot",
+      "has_copper_nugget",
+      "has_electric_scooter",
+      "has_charging_station",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "scooters:potato_battery_with_zinc"
+    ]
+  },
+  "sends_telemetry_event": false
+}

--- a/src/main/resources/data/scooters/advancements/recipes/raw_tire_a.json
+++ b/src/main/resources/data/scooters/advancements/recipes/raw_tire_a.json
@@ -1,0 +1,57 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_coal_block": {
+      "conditions": {
+        "items": [
+          {
+            "tag": "c:coal_blocks"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_iron_ingot": {
+      "conditions": {
+        "items": [
+          {
+            "tag": "c:iron_ingots"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+	"has_iron_bars": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:iron_bars"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "scooters:raw_tire_a"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_coal_block",
+      "has_iron_ingot",
+      "has_iron_bars",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "scooters:raw_tire_a"
+    ]
+  },
+  "sends_telemetry_event": false
+}

--- a/src/main/resources/data/scooters/advancements/recipes/raw_tire_b.json
+++ b/src/main/resources/data/scooters/advancements/recipes/raw_tire_b.json
@@ -1,0 +1,57 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+    "has_coal_block": {
+      "conditions": {
+        "items": [
+          {
+            "tag": "c:coal_blocks"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_iron_ingot": {
+      "conditions": {
+        "items": [
+          {
+            "tag": "c:iron_ingots"
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+	"has_iron_bars": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "minecraft:iron_bars"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "scooters:raw_tire_b"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_coal_block",
+      "has_iron_ingot",
+      "has_iron_bars",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "scooters:raw_tire_b"
+    ]
+  },
+  "sends_telemetry_event": false
+}

--- a/src/main/resources/data/scooters/advancements/recipes/tire_vulcanization.json
+++ b/src/main/resources/data/scooters/advancements/recipes/tire_vulcanization.json
@@ -1,0 +1,35 @@
+{
+  "parent": "minecraft:recipes/root",
+  "criteria": {
+	"has_raw_tire": {
+      "conditions": {
+        "items": [
+          {
+            "items": [
+              "scooters:raw_tire"
+            ]
+          }
+        ]
+      },
+      "trigger": "minecraft:inventory_changed"
+    },
+    "has_the_recipe": {
+      "conditions": {
+        "recipe": "scooters:tire_vulcanization"
+      },
+      "trigger": "minecraft:recipe_unlocked"
+    }
+  },
+  "requirements": [
+    [
+      "has_raw_tire",
+      "has_the_recipe"
+    ]
+  ],
+  "rewards": {
+    "recipes": [
+      "scooters:tire_vulcanization"
+    ]
+  },
+  "sends_telemetry_event": false
+}


### PR DESCRIPTION
adds advancements to unlock the various recipes of the mod so that the recipes can be viewed without the use of a recipe list mod

Worth noting both scooters due to their custom recipe handler show up as Air in the vanilla recipe book but the recipes themselves still work fine